### PR TITLE
Refactor: Change the main data flow of the app to account for external API calls

### DIFF
--- a/src/lib/client/components/modules/home-page/HomePage.svelte
+++ b/src/lib/client/components/modules/home-page/HomePage.svelte
@@ -3,8 +3,13 @@
   import TeamsSection from "./TeamsSection.svelte";
   import PlayersSection from "./PlayersSection.svelte";
   import { getHeaderTabState } from "./home-page.svelte";
+  import { getAllPlayersArrayContext, getAllTeamsArrayContext } from "$lib/context";
 </script>
 
 <Header />
-<TeamsSection isNotDisplayed={getHeaderTabState() === null || getHeaderTabState() !== "teams"} />
-<PlayersSection isNotDisplayed={getHeaderTabState() === null || getHeaderTabState() !== "players"} />
+{#if getAllPlayersArrayContext().length === 0 || getAllTeamsArrayContext().length === 0}
+  <p>Error!!!</p>
+{:else}
+  <TeamsSection isNotDisplayed={getHeaderTabState() === null || getHeaderTabState() !== "teams"} />
+  <PlayersSection isNotDisplayed={getHeaderTabState() === null || getHeaderTabState() !== "players"} />
+{/if}

--- a/src/lib/client/components/modules/home-page/PlayersSection.svelte
+++ b/src/lib/client/components/modules/home-page/PlayersSection.svelte
@@ -4,11 +4,12 @@
     getInitialPlayerSearchInputValue,
     setInitialPlayerSearchInputValue,
   } from "@client/components/modules/home-page/home-page.svelte";
-  import type { Player, APIResponse } from "$lib/types";
+  import type { Player } from "$lib/types";
   import type { Attachment } from "svelte/attachments";
-  import { getAllTeamsArrayContext } from "$lib/context";
+  import { getAllTeamsArrayContext, getAllPlayersArrayContext } from "$lib/context";
 
   const allTeamsArrray = getAllTeamsArrayContext();
+  const allPlayersArray = getAllPlayersArrayContext();
 
   let section: HTMLElement | undefined = undefined;
 
@@ -17,7 +18,7 @@
   let { isNotDisplayed }: { isNotDisplayed: boolean } = $props();
 
   let searchInputValue: string = $state("");
-  let result: null | Promise<Player[]> = $state(null);
+  let result: null | Player[] | string = $state(null);
 
   const myAttachment: Attachment = function () {
     searchInputValue = getInitialPlayerSearchInputValue();
@@ -35,18 +36,24 @@
     return false;
   };
 
-  const onSubmit = async function (
-    e: SubmitEvent & {
-      currentTarget: EventTarget & HTMLFormElement;
-    },
-  ) {
-    e.preventDefault();
-    const res = await fetch(`/api/players?search=${searchInputValue.trim()}`);
-    const data = (await res.json()) as APIResponse<Player[]>;
-    if (!data.success) {
-      throw new Error(data.error);
+  const updateResultState = async function () {
+    const searchInput = searchInputValue.trim();
+    if (!searchInput || searchInput === "") {
+      result = "Search input is invalid. Please enter a valid input";
+      return;
     }
-    return data.data;
+
+    const searchedPlayers = allPlayersArray.filter((player) =>
+      player.Name.toLowerCase().includes(searchInput.toLowerCase()),
+    );
+
+    if (searchedPlayers.length === 0) {
+      result = "No players found with that search input value";
+      return;
+    }
+
+    result = searchedPlayers;
+    return;
   };
 </script>
 
@@ -59,8 +66,9 @@
     <div class="flex justify-center">
       <form
         onsubmit={(e) => {
+          e.preventDefault();
           setInitialPlayerSearchInputValue(searchInputValue);
-          result = onSubmit(e);
+          updateResultState();
         }}
       >
         <label class="mb-5 flex flex-col">
@@ -82,30 +90,26 @@
         </button>
       </form>
     </div>
-    {#if result !== null}
-      {#await result}
-        <p>Loading...</p>
-      {:then results}
-        {#each results as player (player.PlayerID)}
-          <div>
-            <a
-              href={`/player/${player.PlayerID}`}
-              class={{
-                "text-stone-300": true,
-                "hover:text-afc": getHoverColor(player) === "AFC",
-                "hover:text-nfc": getHoverColor(player) === "NFC",
-                "hover:text-stone-400": !getHoverColor(player),
-              }}
-            >
-              {player.Name}</a
-            >
-          </div>
-        {/each}
-      {:catch error}
-        <p>{(error as Error).message}</p>
-      {/await}
-    {:else}
+    {#if result === null}
       <p>Click the submit button</p>
+    {:else if typeof result === "string"}
+      <p>{result}</p>
+    {:else}
+      {#each result as player (player.PlayerID)}
+        <div>
+          <a
+            href={`/player/${player.PlayerID}`}
+            class={{
+              "text-stone-300": true,
+              "hover:text-afc": getHoverColor(player) === "AFC",
+              "hover:text-nfc": getHoverColor(player) === "NFC",
+              "hover:text-stone-400": !getHoverColor(player),
+            }}
+          >
+            {player.Name}</a
+          >
+        </div>
+      {/each}
     {/if}
   </div>
 </section>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,2 +1,3 @@
 export const ALL_TEAMS_ARRAY_CONTEXT_KEY = "allTeamsArray";
+export const ALL_PLAYERS_ARRAY_CONTEXT_KEY = "allPlayersArray";
 export const INITIAL_PLAYER_SEARCH_INPUT_CONTEXT_KEY = "initialPlayerSearchInput";

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import { getContext, setContext } from "svelte";
-import type { Team } from "./types";
-import { ALL_TEAMS_ARRAY_CONTEXT_KEY } from "./constants";
+import type { Team, Player } from "./types";
+import { ALL_TEAMS_ARRAY_CONTEXT_KEY, ALL_PLAYERS_ARRAY_CONTEXT_KEY } from "./constants";
 
 export const setAllTeamsArrayContext = function (allTeamsArr: Team[]) {
   setContext(ALL_TEAMS_ARRAY_CONTEXT_KEY, allTeamsArr);
@@ -10,4 +10,13 @@ export const setAllTeamsArrayContext = function (allTeamsArr: Team[]) {
 export const getAllTeamsArrayContext = function () {
   const allTeamsArray = getContext(ALL_TEAMS_ARRAY_CONTEXT_KEY) as Team[];
   return allTeamsArray;
+};
+
+export const setAllPlayersArrayContext = function (allPlayersArr: Player[]) {
+  setContext(ALL_PLAYERS_ARRAY_CONTEXT_KEY, allPlayersArr);
+};
+
+export const getAllPlayersArrayContext = function () {
+  const allPlayersArray = getContext(ALL_PLAYERS_ARRAY_CONTEXT_KEY) as Player[];
+  return allPlayersArray;
 };

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -4,6 +4,9 @@ import { SPORTSDATA_API_KEY } from "$env/static/private";
 export const getAllTeamsFromSportsdataIOAPI = async function () {
   const allTeamsAPIUrl = `https://api.sportsdata.io/v3/nfl/scores/json/Teams?key=${SPORTSDATA_API_KEY}`;
   const res = await fetch(allTeamsAPIUrl);
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
   const allTeams = (await res.json()) as Team[];
   return allTeams;
 };
@@ -11,6 +14,9 @@ export const getAllTeamsFromSportsdataIOAPI = async function () {
 export const getAllAvailablePlayersFromSportsdataIOAPI = async function () {
   const allPlayersAPIURL = `https://api.sportsdata.io/v3/nfl/scores/json/PlayersByAvailable?key=${SPORTSDATA_API_KEY}`;
   const res = await fetch(allPlayersAPIURL);
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
   const allPlayers = (await res.json()) as Player[];
   return allPlayers;
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,15 @@
+import type { LayoutServerLoad } from "./$types";
+import { getAllTeamsFromSportsdataIOAPI, getAllAvailablePlayersFromSportsdataIOAPI } from "$lib/server";
+import type { Team, Player } from "$lib/types";
+
+export const load: LayoutServerLoad = async function ({ setHeaders, url }) {
+  console.log(url.searchParams);
+  try {
+    const promises = Promise.all([getAllTeamsFromSportsdataIOAPI(), getAllAvailablePlayersFromSportsdataIOAPI()]);
+    const [allTeams, allPlayers] = await promises;
+    setHeaders({ "cache-control": "private, max-age=604800" });
+    return { allTeams, allPlayers };
+  } catch (e) {
+    return { allTeams: [], allPlayers: [] } as { allTeams: Team[]; allPlayers: Player[] };
+  }
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import "../app.css";
+  import type { LayoutProps } from "./$types";
+  import { setAllTeamsArrayContext, setAllPlayersArrayContext } from "$lib/context";
 
-  let { children } = $props();
+  let { children, data }: LayoutProps = $props();
+
+  console.log(data.allTeams);
+  console.log(data.allPlayers);
+  setAllTeamsArrayContext(data.allTeams);
+  setAllPlayersArrayContext(data.allPlayers);
 </script>
 
 {@render children()}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,9 +1,0 @@
-import type { PageServerLoad } from "./$types";
-import { getAllTeamsFromSportsdataIOAPI } from "$lib/server";
-
-export const load: PageServerLoad = async function ({ setHeaders, url }) {
-  console.log(url.searchParams);
-  const allTeams = await getAllTeamsFromSportsdataIOAPI();
-  setHeaders({ "cache-control": "private, max-age=604800" });
-  return { allTeams };
-};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
   import HomePage from "@client/components/modules/home-page/HomePage.svelte";
-  import type { PageProps } from "./$types";
-  import { setAllTeamsArrayContext } from "$lib/context";
-
-  let { data }: PageProps = $props();
-  setAllTeamsArrayContext(data.allTeams);
 </script>
 
 <HomePage />


### PR DESCRIPTION
I moved the fetching of all teams and all players to the layout to avoid any extensive API restrictions from SportsDataIO. I then utilised the Svelte Context API to store the objects for use in other parts of the app.